### PR TITLE
Switch to single-star workspace globs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
   # all packages in subdirs of packages/ and apps/
-  - 'packages/**'
-  - 'apps/**'
+  - 'packages/*'
+  - 'apps/*'


### PR DESCRIPTION
- PNPM allows double-star directive globs (e.g. `directoyr/**`) in `pnpm-workspaces.yaml`. However,  PNPM avoids `node_modules` (and perhaps anything in gitignore?) from these glob results....magically. At the moment, `turbo` doesn't do this. Double star glob in `turbo` really means "recursive" and not "recursive except for `node_modules`". Switching to single star fixes this to "any package.json one-level down from `./apps/*` and `/packages/*`" which is what you want. 
- Lodash core's `package.json` keywords is a string with commas, which I did not know was allowed. This has no impact other than `turbo`'s go struct for package.json and json marshal code needs to be updated to allow this in the future. 
- I am going to add an official PNPM starter so that there is just less for folks to do and also tweak that glob code to match PNPM's implementation when using PNPM